### PR TITLE
Switch base image back to Debian Jessie; Flask 0.11 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
-FROM python:2.7-alpine
+FROM python:2.7-slim
 
 MAINTAINER Azavea <systems@azavea.com>
 
 RUN \
-      apk add --no-cache --virtual .build-deps \
-          gcc \
-          libc-dev \
-          libevent-dev \
-          linux-headers \
-          # musl-dev \
-          # python-dev \
-      && apk add --no-cache postgresql-client \
+      apt-get update && apt-get install -y --no-install-recommends \
+          build-essential \
       && pip install --no-cache-dir \
-        gunicorn==19.4.5 \
-        Flask==0.10.1 \
-        gevent==1.1.1 \
-      && apk del .build-deps
+         gunicorn==19.6.0 \
+         Flask==0.11 \
+         gevent==1.1.1 \
+      && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["gunicorn"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docker Repository on Quay.io](https://quay.io/repository/azavea/flask/status "Docker Repository on Quay.io")](https://quay.io/repository/azavea/flask)
 [![Apache V2 License](http://img.shields.io/badge/license-Apache%20V2-blue.svg)](https://github.com/azavea/docker-flask/blob/develop/LICENSE)
 
-A `Dockerfile` based off of [`python:2.7-alpine`](https://registry.hub.docker.com/_/python/) that installs dependencies for a Flask project with Gunicorn as the application server.
+A `Dockerfile` based off of [`python:2.7-slim`](https://registry.hub.docker.com/_/python/) that installs dependencies for a Flask project with Gunicorn as the application server.
 
 Includes:
 
@@ -22,10 +22,11 @@ Then, run the container:
 
 ```bash
 $ docker run --rm --entrypoint pip quay.io/azavea/flask:latest freeze
-Flask==0.10.1
+click==6.6
+Flask==0.11
 gevent==1.1.1
 greenlet==0.4.9
-gunicorn==19.4.5
+gunicorn==19.6.0
 itsdangerous==0.24
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
The Alpine based Python image currently has problems with Docker volumes that are based off of `vboxfs` mounts. This prevents workflows that require the immediate visibly of changes to a `vboxfs` share inside of a running container.

In addition, Flask was upgraded to version 0.11.

---

**Testing**

Go through steps in `README` and ensure that output of installed modules lines up.
