### PR TITLE
Add Flask back to container image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/0.11/requirements.txt
+++ b/0.11/requirements.txt
@@ -1,2 +1,3 @@
+flask==0.11.1
 gunicorn==19.6.0
 gevent==1.2.1

--- a/0.12/requirements.txt
+++ b/0.12/requirements.txt
@@ -1,2 +1,3 @@
+flask==0.12.4
 gunicorn==19.6.0
 gevent==1.2.1

--- a/scripts/test
+++ b/scripts/test
@@ -20,5 +20,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         docker \
             run --rm "quay.io/azavea/flask:$VERSION-python$PYTHON_VERSION-$VARIANT" --version
+
+        docker \
+            run --rm --entrypoint pip \
+            "quay.io/azavea/flask:$VERSION-python$PYTHON_VERSION-$VARIANT" freeze | grep "Flask==${VERSION}"
     fi
 fi


### PR DESCRIPTION
# Overview

This PR adds Flask to `requirements.txt` to ensure that it's installed in the container image. I also added a Flask version check to `scripts/test`.

# Testing
- See [Travis CI output](https://travis-ci.org/azavea/docker-flask/builds/392257698?utm_source=github_status&utm_medium=notification)
- Follow the `README` instructions to run `scripts/cibuild`. Ensure that all tests pass.

```bash
$ CI=1 VERSION=0.12 PYTHON_VERSION=2.7 VARIANT=alpine ./scripts/cibuild
```

Fixes #5 